### PR TITLE
Allow platform dependent linebreaks in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     'max-classes-per-file': 'off',
     'no-use-before-define': 'off',
     'vue/multi-word-component-names': 'off',
-    'linebreak-style': ['error', (process.platform === 'win32' ? 'windows' : 'unix')]
+    'linebreak-style': ['error', process.env.ESLINT_LINEBREAK_WINDOWS ? 'windows' : 'unix']
   },
   parserOptions: {
     parser: '@typescript-eslint/parser',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'max-classes-per-file': 'off',
     'no-use-before-define': 'off',
     'vue/multi-word-component-names': 'off',
+    'linebreak-style': ['error', (process.platform === 'win32' ? 'windows' : 'unix')]
   },
   parserOptions: {
     parser: '@typescript-eslint/parser',


### PR DESCRIPTION
This PR adds an `eslint` rule that allows developers on windows to override the `linebreak-style` check.

fixes #154 

NOTES:
 
An alternative would be for Windows users to force `LF` on checkout using `git` (e.g. [1], [2]), but IMO that's inconvenient and often confusing.

[1]: https://stackoverflow.com/q/2517190
[2]: https://stackoverflow.com/q/1967370