### PR TITLE
add .gitattributes to handle line endings on windows systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Prevent conversion to CRLF in case git core.autocrlf is enabled on windows, to prevent eslint errors.
+#
+# After making changes to `eol` config, *ensure working dir is clean*, then run [1]:
+#
+#     git rm -rf --cached .
+#     git reset --hard HEAD
+#
+# [1]: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+
+*.js text eol=lf
+*.ts text eol=lf
+*.vue text eol=lf


### PR DESCRIPTION
This ensures that line endings for `*.js`, `*.ts`, and `*.vue` files are *not* auto-converted to `CRLF` on Windows systems with git `core.autocrlf` enabled.

fixes #154 