### PR TITLE
Backport "separate build and publish workflows (#166)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,1 @@
-*
-!dist
-!nginx
-!src
-!node_modules/bootstrap
-!node_modules/bootstrap-vue
-!node_modules/prismjs
-!node_modules/vue-select
-!node_modules/vue2-datepicker
+node_modules/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,16 @@
-name: "Test & Build"
+name: test and build
 
 on:
   push:
+    branches:
+      - develop
   pull_request:
+  workflow_dispatch:
 
+concurrency:
+  # prevent duplicate runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -11,127 +18,29 @@ jobs:
 
     strategy:
       matrix:
-        app: [fairdatapoint-index, fairdatapoint]
-        node-version: [16]
-
-    env:
-      PUBLIC_IMAGE: fairdata/${{ matrix.app }}-client
-      PRIVATE_IMAGE: ${{ secrets.PRIVATE_REGISTRY_URL }}/${{ matrix.app }}-client
+        # todo: upgrade to latest supported LTS node version
+        # https://nodejs.org/en/about/previous-releases#release-schedule
+        node: [16]
 
     steps:
-      # (1) -> Preparations
-      - name: Checkout repo
-        uses: actions/checkout@v3
+      - # https://github.com/actions/checkout
+        name: Checkout repo
+        uses: actions/checkout@v4
+
+      - # https://github.com/actions/setup-node
+        name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies from package-lock.json
+        run: npm clean-install
 
-      # (2) -> Build app and Docker image
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         run: npm run build
 
-      - name: Create build info
-        run: ./scripts/build_info.sh
-
-      # (3) -> Docker [test build]
-      - name: Docker meta [test]
-        id: meta-test
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.PUBLIC_IMAGE }}
-          tags: |
-            type=sha
-
-      - name: Docker build+push [test]
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: fdp_app=${{ matrix.app }}
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: ${{ steps.meta-test.outputs.tags }}
-          labels: ${{ steps.meta-test.outputs.labels }}
-
-      # (4) -> Docker [private registry]
-      - name: Docker login [private]
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ secrets.PRIVATE_REGISTRY_URL }}
-          username: ${{ secrets.PRIVATE_REGISTRY_USERNAME }}
-          password: ${{ secrets.PRIVATE_REGISTRY_PASSWORD }}
-
-      - name: Docker meta [private]
-        id: meta-private
-        if: github.event_name != 'pull_request'
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.PRIVATE_IMAGE }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-
-      - name: Docker build+push [private]
-        uses: docker/build-push-action@v3
-        if: github.event_name != 'pull_request' && steps.meta-private.outputs.tags != ''
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: fdp_app=${{ matrix.app }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta-private.outputs.tags }}
-          labels: ${{ steps.meta-private.outputs.labels }}
-
-      # (5) -> Docker [Docker Hub]
-      - name: Docker login [public]
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
-      - name: Docker meta [public]
-        id: meta-public
-        if: github.event_name != 'pull_request'
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.PUBLIC_IMAGE }}
-          tags: |
-            type=raw,value=develop,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Docker build+push [public]
-        uses: docker/build-push-action@v3
-        if: github.event_name != 'pull_request' && steps.meta-public.outputs.tags != ''
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: fdp_app=${{ matrix.app }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta-public.outputs.tags }}
-          labels: ${{ steps.meta-public.outputs.labels }}
-
-
+      # todo: without tests this does not do much

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+  release:
+    types:
+      - created
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    uses: FAIRDataTeam/github-workflows/.github/workflows/docker-publish.yml@v2
+    secrets: inherit
+    with:
+      file: './Dockerfile'
+      platforms: linux/amd64
+      push: ${{ github.event_name == 'push' || github.event_name == 'release' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,42 @@
-FROM nginx:alpine
+###### BUILD STAGE ######
+# https://v2.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
 
+FROM node:16-alpine AS build-stage
+WORKDIR /app
+
+# install-layer
+COPY package*.json ./
+RUN npm install
+
+# build-layer
+COPY . .
+RUN npm run build
+
+# update version info
+RUN apk add git
+RUN scripts/build_info.sh
+
+###### DISTRIBUTION STAGE ######
+
+FROM nginx:alpine AS dist-stage
+
+# sass (used in start.sh)
 RUN apk add --no-cache libsass sassc && rm -f /tmp/* /etc/apk/cache/*
+COPY --from=build-stage /app/src/scss src/scss
+COPY --from=build-stage /app/src/components src/components
+COPY --from=build-stage /app/src/views src/views
+COPY --from=build-stage /app/node_modules/bootstrap/scss src/~bootstrap/scss
+COPY --from=build-stage /app/node_modules/bootstrap-vue/src src/~bootstrap-vue/src
+COPY --from=build-stage /app/node_modules/prismjs/themes src/~prismjs/themes
+COPY --from=build-stage /app/node_modules/vue-select/src/scss src/~vue-select/src/scss
+COPY --from=build-stage /app/node_modules/vue2-datepicker/scss src/~vue2-datepicker/scss
 
-COPY node_modules/bootstrap src/~bootstrap
-COPY node_modules/bootstrap-vue src/~bootstrap-vue
-COPY node_modules/prismjs src/~prismjs
-COPY node_modules/vue-select src/~vue-select
-COPY node_modules/vue2-datepicker src/~vue2-datepicker
-
+# nginx
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY nginx/start.sh /start.sh
 
-COPY src src
-COPY dist /usr/share/nginx/html
+# app files (static)
+COPY --from=build-stage /app/dist /usr/share/nginx/html
 
 ARG fdp_app
 ENV APP=$fdp_app

--- a/scripts/build_info.sh
+++ b/scripts/build_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
* add build stage to Dockerfile

  - clean up Dockerfile and .dockerignore accordingly
  - move build_info.sh call from github action into build stage
  - convert build_info.sh from bash to sh (alpine has no bash)

* separate build and publish workflows

  using reusable workflows from FAIRDataTeam/github-workflows

* explicit stage name in Dockerfile

* limit docker image support to linux/amd64 (because linux/arm64 fails to build: see [this comment])

* add minimal sass dependencies in Dockerfile

>[!IMPORTANT]
>The previous build workflow created two separate docker images, one for the normal client and one for the index client.
>The present changes only create a single docker image that defaults to the normal client.
>To enable the index functionality, we need to specify the `APP` environment variable in our compose file (or using `docker run -e ...`):
>```yaml
>  fdp-client:
>    image: fairdata/fairdatapoint-client:1.17.1
>    environment:
>      APP: fairdatapoint-index
>      FDP_HOST: fdp:8080
>```
>
>This works as follows: https://github.com/FAIRDataTeam/FAIRDataPoint-client/blob/9843f9a8e5ba5acab4619f0f0b4a7e21c1704245/nginx/start.sh#L6-L10
>
>Also note that `APP` does *not* need to be specified for the v2 client (develop), because that has been modified to autodetect index functionality.

[this comment]: https://github.com/FAIRDataTeam/FAIRDataPoint-client/pull/166#issuecomment-2690160209