### PR TITLE
Backport "Fix support for xsd:dateTime and xsd:date fields (#183)"

### DIFF
--- a/src/components/ShaclForm/Editor/DatePickerEditor.vue
+++ b/src/components/ShaclForm/Editor/DatePickerEditor.vue
@@ -42,7 +42,8 @@ export default class DatePickerEditor extends Vue {
   }
 
   onInput(val) {
-    this.$emit('input', moment(val).toDate())
+    // only convert to JS Date when we actually need the time component
+    this.$emit('input', this.type === 'date' ? val : moment(val).toDate())
   }
 }
 </script>

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -9,7 +9,12 @@ function getName(field: FormField): string {
 }
 
 function isDatetime(field: FormField): boolean {
-  return field.datatype === XSD('dateTime').value
+  // todo: rename to isDate(), consistent with the JS Date type
+  const dateDataTypes = [
+    XSD('dateTime').value,
+    XSD('date').value,
+  ]
+  return dateDataTypes.includes(field.datatype)
 }
 
 function isIRI(field: FormField): boolean {

--- a/src/components/ShaclForm/formData.ts
+++ b/src/components/ShaclForm/formData.ts
@@ -1,6 +1,6 @@
 import * as $rdf from 'rdflib'
 import _ from 'lodash'
-import { PREFIXES, RDF, XSD } from '@/rdf/namespaces'
+import { PREFIXES, RDF } from '@/rdf/namespaces'
 import { FormShape } from '@/components/ShaclForm/Parser/SHACLFormParser'
 import fieldUtils from '@/components/ShaclForm/fieldUtils'
 import valueUtils from '@/components/ShaclForm/valueUtils'
@@ -117,9 +117,18 @@ function createQuads(
           extraQuads.push($rdf.quad(value, RDF('type'), $rdf.namedNode(field.class), null))
         }
 
+        // $rdf.quad() converts input values to Literal with auto-detected datatype.
+        // However, we want the Literal.datatype to match field.datatype.
+        // By creating the Literal ourselves, we can override the datatype,
+        // and it won't be modified by $rdf.quad().
         let wrappedValue = value
         if (hasValue && field && field.datatype) {
-          wrappedValue = $rdf.literal(value, field.datatype)
+          // Create Literal from value so we can override the datatype.
+          // Note that fromValue() auto-detects the datatype and converts JS Date values to UTC,
+          // using a custom iso 8601 compliant string representation YYYY-MM-DDTHH:MM:SSZ
+          wrappedValue = $rdf.Literal.fromValue(value)
+          // Override auto-detected datatype
+          wrappedValue.datatype.value = field.datatype
         }
 
         return hasValue

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -80,7 +80,7 @@ function wrapShaclValue(fieldConfig, value) {
     case DASH('URIViewer').value:
       return { label: value, uri: value }
     default:
-      if (fieldConfig.datatype === XSD('dateTime').value) {
+      if (fieldUtils.isDatetime(fieldConfig)) {
         return { label: moment(value).format(config.dateFormat) }
       }
       if (fieldConfig.datatype === XSD('boolean').value) {


### PR DESCRIPTION
Refer to #183 for details

>[!NOTE]
>Testing this with a default FDP Dataset will still cause a validation error, because the default Dataset schema (defined in the FDP repo) still uses `xsd:dateTime`, in combination with a `dash:DatePickerEditor`, for the fields `issued` and `modified`:
>```
>:DatasetShape a sh:NodeShape ;
>  sh:targetClass dcat:Dataset ;
>  sh:property [
>    sh:path dct:issued ;
>    sh:datatype xsd:dateTime ;
>    sh:maxCount 1 ;
>    dash:editor dash:DatePickerEditor ;
>    dash:viewer dash:LiteralViewer ;
>    sh:order 20 ;
>  ], ...
>```
>
>This should be changed to `dash:DateTimePickerEditor`.
>(the specs say the data type is `xsd:dateTime`) 

