### PR TITLE
Display optional blank node as list

### DIFF
--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -162,7 +162,7 @@ export default class FormRenderer extends Vue {
   }
 
   isList(field) {
-    return fieldUtils.isList(field)
+    return fieldUtils.isList(field) || fieldUtils.isOptionalBlankNode(field)
   }
 
   canBeRemoved(field) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -135,7 +135,7 @@ export default class FormRenderer extends Vue {
   }
 
   createDefaultValueArray(field) {
-    if (field.minCount === 1 || (field.maxCount === 1 && !fieldUtils.isOptionalBlankNode(field))) {
+    if (field.minCount === 1 || (field.maxCount === 1 && !fieldUtils.isOptionalNode(field))) {
       return [this.createDefaultValue(field)]
     }
 
@@ -162,7 +162,7 @@ export default class FormRenderer extends Vue {
   }
 
   isList(field) {
-    return fieldUtils.isList(field) || fieldUtils.isOptionalBlankNode(field)
+    return fieldUtils.isList(field) || fieldUtils.isOptionalNode(field)
   }
 
   canBeRemoved(field) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -88,7 +88,7 @@ import _ from 'lodash'
 import FormInput from '@/components/ShaclForm/FormInput.vue'
 import fieldUtils from '@/components/ShaclForm/fieldUtils'
 import { ValidationReport } from '@/components/ShaclForm/Parser/ValidationReport'
-import { DASH, SHACL } from '@/rdf/namespaces'
+import { SHACL } from '@/rdf/namespaces'
 
 @Component({
   name: 'FormRenderer',
@@ -135,7 +135,7 @@ export default class FormRenderer extends Vue {
   }
 
   createDefaultValueArray(field) {
-    if (field.minCount === 1 || (field.maxCount === 1 && (!field.editor || field.editor !== DASH('BlankNodeEditor').value))) {
+    if (field.minCount === 1 || (field.maxCount === 1 && !fieldUtils.isOptionalBlankNode(field))) {
       return [this.createDefaultValue(field)]
     }
 

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -88,7 +88,7 @@ import _ from 'lodash'
 import FormInput from '@/components/ShaclForm/FormInput.vue'
 import fieldUtils from '@/components/ShaclForm/fieldUtils'
 import { ValidationReport } from '@/components/ShaclForm/Parser/ValidationReport'
-import { SHACL } from '@/rdf/namespaces'
+import { DASH, SHACL } from '@/rdf/namespaces'
 
 @Component({
   name: 'FormRenderer',
@@ -135,7 +135,7 @@ export default class FormRenderer extends Vue {
   }
 
   createDefaultValueArray(field) {
-    if (field.minCount === 1 || field.maxCount === 1) {
+    if (field.minCount === 1 || (field.maxCount === 1 && (!field.editor || field.editor !== DASH('BlankNodeEditor').value))) {
       return [this.createDefaultValue(field)]
     }
 

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { DASH, SHACL, XSD } from '@/rdf/namespaces'
+import { SHACL, XSD } from '@/rdf/namespaces'
 import rdfUtils from '@/rdf/utils'
 import { FormField } from '@/components/ShaclForm/Parser/SHACLFormParser'
 
@@ -34,7 +34,7 @@ function isRequired(field: FormField): boolean {
 }
 
 function isOptionalNode(field: FormField): boolean {
-  return field.editor === DASH('BlankNodeEditor').value && !field.minCount && field.maxCount === 1
+  return field.nodeShape && !field.minCount && field.maxCount === 1
 }
 
 function isBoolean(field: FormField): boolean {

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -33,7 +33,7 @@ function isRequired(field: FormField): boolean {
   return field.minCount > 0
 }
 
-function isOptionalBlankNode(field: FormField): boolean {
+function isOptionalNode(field: FormField): boolean {
   return field.editor === DASH('BlankNodeEditor').value && !field.minCount && field.maxCount === 1
 }
 
@@ -65,7 +65,7 @@ export default {
   isIRI,
   isList,
   isLiteral,
-  isOptionalBlankNode,
+  isOptionalNode,
   isRequired,
   isBoolean,
   isInteger,

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { SHACL, XSD } from '@/rdf/namespaces'
+import { DASH, SHACL, XSD } from '@/rdf/namespaces'
 import rdfUtils from '@/rdf/utils'
 import { FormField } from '@/components/ShaclForm/Parser/SHACLFormParser'
 
@@ -33,6 +33,10 @@ function isRequired(field: FormField): boolean {
   return field.minCount > 0
 }
 
+function isOptionalBlankNode(field: FormField): boolean {
+  return field.editor === DASH('BlankNodeEditor').value && !field.minCount && field.maxCount === 1
+}
+
 function isBoolean(field: FormField): boolean {
   return field.datatype === XSD('boolean').value
 }
@@ -61,6 +65,7 @@ export default {
   isIRI,
   isList,
   isLiteral,
+  isOptionalBlankNode,
   isRequired,
   isBoolean,
   isInteger,


### PR DESCRIPTION
This is a workaround that uses the existing "list" functionality to facilitate optional blank nodes with required fields:

![image](https://github.com/user-attachments/assets/dcc3fbcd-d972-4dba-9904-6518afd23e32)


This may not be the best UX, but I think it is one of the least invasive solutions.

fixes #178 

this is an alternative to #180, because that introduced some undesired side effects