### PR TITLE
Enforce `sh:maxCount` in forms

### DIFF
--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -171,7 +171,10 @@ export default class FormRenderer extends Vue {
   }
 
   addValue(field) {
-    this.data[field.path].push(this.createDefaultValue(field))
+    const maxCount: number = _.get(field, 'maxCount', 0)
+    if (maxCount === 0 || this.data[field.path].length < maxCount) {
+      this.data[field.path].push(this.createDefaultValue(field))
+    }
   }
 
   removeValue(field, index) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -173,8 +173,8 @@ export default class FormRenderer extends Vue {
 
   canAddValue(field) {
     const count = this.data[field.path].length
-    const maxCount: number = _.get(field, 'maxCount', 0)
-    return maxCount === 0 || count < maxCount
+    const maxCount: number | null = _.get(field, 'maxCount', null)
+    return maxCount === null || count < maxCount
   }
 
   addValue(field) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -172,8 +172,9 @@ export default class FormRenderer extends Vue {
   }
 
   canAddValue(field) {
+    const values = this.data[field.path].length
     const maxCount: number = _.get(field, 'maxCount', 0)
-    return maxCount === 0 || this.data[field.path].length < maxCount
+    return maxCount === 0 || values < maxCount
   }
 
   addValue(field) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -65,6 +65,7 @@
         <button
           v-if="isList(field)"
           class="btn btn-link"
+          :hidden="!canAddValue(field)"
           @click.prevent="addValue(field)"
         >
           <fa :icon="['fas', 'plus']" />
@@ -170,11 +171,13 @@ export default class FormRenderer extends Vue {
     return this.isList(field) && values > minCount
   }
 
-  addValue(field) {
+  canAddValue(field) {
     const maxCount: number = _.get(field, 'maxCount', 0)
-    if (maxCount === 0 || this.data[field.path].length < maxCount) {
-      this.data[field.path].push(this.createDefaultValue(field))
-    }
+    return maxCount === 0 || this.data[field.path].length < maxCount
+  }
+
+  addValue(field) {
+    this.data[field.path].push(this.createDefaultValue(field))
   }
 
   removeValue(field, index) {

--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -166,15 +166,15 @@ export default class FormRenderer extends Vue {
   }
 
   canBeRemoved(field) {
-    const values = this.data[field.path].length
+    const count = this.data[field.path].length
     const minCount = _.get(field, 'minCount', 0)
-    return this.isList(field) && values > minCount
+    return this.isList(field) && count > minCount
   }
 
   canAddValue(field) {
-    const values = this.data[field.path].length
+    const count = this.data[field.path].length
     const maxCount: number = _.get(field, 'maxCount', 0)
-    return maxCount === 0 || values < maxCount
+    return maxCount === 0 || count < maxCount
   }
 
   addValue(field) {


### PR DESCRIPTION
Hide the "Add" button if `sh:maxCount` has been reached.

For example, with `sh:maxCount 2` in the schema, the "Add" button is visible as long as there are fewer than `2` items: 

![image](https://github.com/user-attachments/assets/df906e9e-5ff3-40e7-a1c9-ff9d17476ed5)

but it is hidden if there are `2`

![image](https://github.com/user-attachments/assets/0baf2ec9-fc8a-416f-9c5b-a663fd69081e)

The "Add" button becomes visible again if we remove one or more items using the "x" (remove) buttons.

fixes #195 
fixes #202