### PR TITLE
Fix removal of blank nodes

### DIFF
--- a/src/components/ShaclForm/formData.ts
+++ b/src/components/ShaclForm/formData.ts
@@ -166,7 +166,7 @@ export function toRdf(
   }
   clear($rdf.namedNode(subjectStr), shape.fields)
 
-  store.addAll(createQuads(data, rdf, shape))
+  store.addAll(createQuads(data, store, shape))
 
   // @ts-ignore
   const serializer = $rdf.Serializer(rdf)

--- a/src/components/ShaclForm/formData.ts
+++ b/src/components/ShaclForm/formData.ts
@@ -156,7 +156,10 @@ export function toRdf(
       if (field.nodeShape) {
         store
           .statementsMatching(subject, $rdf.namedNode(field.path))
-          .forEach((statement) => clear(statement.object, field.nodeShape.fields))
+          .forEach((statement) => {
+            clear(statement.object, field.nodeShape.fields)
+            store.removeMany(statement.object)
+          })
       }
       store.removeMany(subject, $rdf.namedNode(field.path))
     })

--- a/src/components/ShaclForm/formData.ts
+++ b/src/components/ShaclForm/formData.ts
@@ -148,24 +148,42 @@ export function toRdf(
   subjectStr: string,
   shape: FormShape,
 ): string {
+  // Create a copy of the original RDF Store (a.k.a. IndexedFormula)
+  // which contains all RDF statements describing the (exising) resource
   const store = $rdf.graph()
   store.addAll(rdf.statementsMatching(undefined, undefined, undefined))
 
+  /**
+   * Recursively clears all RDF statements related to specified form fields
+   * (as defined in the SHACL shape) from the in-memory RDF store.
+   *
+   * @param {$rdf.NamedNode} subject - An RDF named node (IRI)
+   * @param {Array} fields - An array of Fields representing SHACL properties
+   * @returns {void}
+   */
   const clear = (subject, fields) => {
     fields.forEach((field) => {
+      // Recursive case
       if (field.nodeShape) {
+        // Note that statement.object now represents a blank node
         store
           .statementsMatching(subject, $rdf.namedNode(field.path))
           .forEach((statement) => {
+            // Recursive call is necessary to support nesting of blank nodes
             clear(statement.object, field.nodeShape.fields)
+            // Remove the blank node itself
             store.removeMany(statement.object)
           })
       }
+      // Base case
       store.removeMany(subject, $rdf.namedNode(field.path))
     })
   }
+
+  // Remove all existing statements related to the present shape from the RDF store
   clear($rdf.namedNode(subjectStr), shape.fields)
 
+  // Create new statements from form data, and add them to the RDF store
   store.addAll(createQuads(data, store, shape))
 
   // @ts-ignore


### PR DESCRIPTION
From the code, I inferred that the `clear()` function in `formData.ts` is supposed to remove all RDF statements related to the fields rendered in the HTML form from the in-memory RDF store.

These statements are reconstructed later, in `createQuads()`, based on the form data.

However, the `clear()` function failed to remove the blank node *type* statements, because these are not included in `field.nodeshape.fields` (instead, they are found in `field.nodeshape.targetClasses`). So we were left with orphaned statements like `[ a foaf:Agent ].` as described in #200.

To fix this, I added the line `store.removeMany(statement.object)`, which (afaik) actually removes all statements related to the blank node, including the type statement. The recursive call to `clear()` is still necessary to cover the case of nested blank nodes.

This fixed the removal of the blank node, so we did not see the orphaned type statements anymore (`[ a foaf:Agent ].`). However, `createQuads()` subsequently failed to restore these *type* statements when processing the form data.

I assumed this was caused by the fact that `createQuads()` used the original RDF store (`rdf`) for reference, instead of the updated RDF store (`store`), so I changed that as well.

fixes #200