### PR TITLE
Backport: Detect optional nodes using nodeShape instead of BlankNodeEditor

### DIFF
--- a/src/components/ShaclForm/FormRenderer.vue
+++ b/src/components/ShaclForm/FormRenderer.vue
@@ -135,7 +135,7 @@ export default class FormRenderer extends Vue {
   }
 
   createDefaultValueArray(field) {
-    if (field.minCount === 1 || (field.maxCount === 1 && !fieldUtils.isOptionalBlankNode(field))) {
+    if (field.minCount === 1 || (field.maxCount === 1 && !fieldUtils.isOptionalNode(field))) {
       return [this.createDefaultValue(field)]
     }
 
@@ -162,7 +162,7 @@ export default class FormRenderer extends Vue {
   }
 
   isList(field) {
-    return fieldUtils.isList(field) || fieldUtils.isOptionalBlankNode(field)
+    return fieldUtils.isList(field) || fieldUtils.isOptionalNode(field)
   }
 
   canBeRemoved(field) {

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { DASH, SHACL, XSD } from '@/rdf/namespaces'
+import { SHACL, XSD } from '@/rdf/namespaces'
 import rdfUtils from '@/rdf/utils'
 import { FormField } from '@/components/ShaclForm/Parser/SHACLFormParser'
 
@@ -34,7 +34,7 @@ function isRequired(field: FormField): boolean {
 }
 
 function isOptionalNode(field: FormField): boolean {
-  return field.editor === DASH('BlankNodeEditor').value && !field.minCount && field.maxCount === 1
+  return field.nodeShape && !field.minCount && field.maxCount === 1
 }
 
 function isBoolean(field: FormField): boolean {

--- a/src/components/ShaclForm/fieldUtils.ts
+++ b/src/components/ShaclForm/fieldUtils.ts
@@ -33,7 +33,7 @@ function isRequired(field: FormField): boolean {
   return field.minCount > 0
 }
 
-function isOptionalBlankNode(field: FormField): boolean {
+function isOptionalNode(field: FormField): boolean {
   return field.editor === DASH('BlankNodeEditor').value && !field.minCount && field.maxCount === 1
 }
 
@@ -65,7 +65,7 @@ export default {
   isIRI,
   isList,
   isLiteral,
-  isOptionalBlankNode,
+  isOptionalNode,
   isRequired,
   isBoolean,
   isInteger,


### PR DESCRIPTION
See rationale in https://github.com/FAIRDataTeam/FAIRDataPoint-client/pull/194#issuecomment-3012419097

Checking for `dash:BlankNodeEditor` is not only fragile, but probably incorrect.
The proper solution is to check for presence of a `sh:NodeShape`.
