### PR TITLE
Fix serializer constructor argument

### DIFF
--- a/src/components/ShaclForm/formData.ts
+++ b/src/components/ShaclForm/formData.ts
@@ -187,7 +187,7 @@ export function toRdf(
   store.addAll(createQuads(data, store, shape))
 
   // @ts-ignore
-  const serializer = $rdf.Serializer(rdf)
+  const serializer = $rdf.Serializer(store)
   serializer.setFlags('sir')
 
   Object.entries(PREFIXES).forEach(([prefix, url]) => {


### PR DESCRIPTION
Construct `Serializer` with `store` instead of `rdf`.

This should have been done here: https://github.com/FAIRDataTeam/FAIRDataPoint-client/commit/7e7c72dcf4d4903fc52e774e53c5d694810889d6#diff-ef3921a4436ad0844211507355b994db998926fe0693538d6972c9711ab8a71a

fixes #220


