### PR TITLE
List children based on all targetclasses in schema

### DIFF
--- a/src/entity/EntityConfig.ts
+++ b/src/entity/EntityConfig.ts
@@ -161,13 +161,19 @@ export class EntityConfig {
     graph: Graph,
     meta = null,
   ) {
-    const typePredicate = $rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
-    const typeNode = $rdf.namedNode(_.first(entity.targetClassUris))
-
-    return graph.store.match(null, typePredicate, typeNode)
-      .map((c) => {
-        const id = rdfUtils.pathTerm(_.get(c.subject, 'value'))
-        const options = { subject: c.subject }
+    const typePredicate: $rdf.NamedNode = $rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+    // Get all quads matching the specified target classes.
+    // Likely to include duplicate subjects because FDP specifies both Resource and its subclasses.
+    const matchingQuads: $rdf.Quad[] = entity.targetClassUris.flatMap(
+      (targetClass: string) => graph.store.match(null, typePredicate, $rdf.namedNode(targetClass)),
+    )
+    // Extract unique subjects
+    const uniqueSubjects = [...new Set(matchingQuads.map((q: $rdf.Quad) => q.subject))]
+    // Return objects with relevant information about the subject
+    return uniqueSubjects.map(
+      (rdfSubject) => {
+        const id = rdfUtils.pathTerm(_.get(rdfSubject, 'value'))
+        const options = { subject: rdfSubject }
 
         const tags = child.listView.tagsUri
           ? graph.findAll($rdf.namedNode(child.listView.tagsUri), options)
@@ -182,7 +188,7 @@ export class EntityConfig {
           : []
 
         const stateChildren = _.get(meta, 'state.children', {})
-        const prefix = stateChildren[c.subject.value] === 'DRAFT' ? '[DRAFT] ' : ''
+        const prefix = stateChildren[rdfSubject.value] === 'DRAFT' ? '[DRAFT] ' : ''
 
         return {
           title: prefix + graph.findOne(DCT('title'), options),
@@ -194,7 +200,8 @@ export class EntityConfig {
             metadata.dateField('Modified', graph.findOne(FDPO('metadataModified'), options)),
           ].concat(extraMetadata),
         }
-      })
+      },
+    )
   }
 
   // BREADCRUMBS --

--- a/src/entity/EntityConfig.ts
+++ b/src/entity/EntityConfig.ts
@@ -164,16 +164,18 @@ export class EntityConfig {
     const typePredicate: $rdf.NamedNode = $rdf.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
     // Get all quads matching the specified target classes.
     // Likely to include duplicate subjects because FDP specifies both Resource and its subclasses.
-    const matchingQuads: $rdf.Quad[] = entity.targetClassUris.flatMap(
+    const targetClassQuads: $rdf.Quad[] = entity.targetClassUris.flatMap(
       (targetClass: string) => graph.store.match(null, typePredicate, $rdf.namedNode(targetClass)),
     )
-    // Extract unique subjects
-    const uniqueSubjects = [...new Set(matchingQuads.map((q: $rdf.Quad) => q.subject))]
-    // Return objects with relevant information about the subject
+    // Determine unique subjects corresponding to the target classes
+    const uniqueSubjects: $rdf.Quad_Subject[] = [
+      ...new Set(targetClassQuads.map((q: $rdf.Quad) => q.subject)),
+    ]
+    // Extract relevant information from the subjects
     return uniqueSubjects.map(
-      (rdfSubject) => {
-        const id = rdfUtils.pathTerm(_.get(rdfSubject, 'value'))
-        const options = { subject: rdfSubject }
+      (subject: $rdf.Quad_subject) => {
+        const id = rdfUtils.pathTerm(_.get(subject, 'value'))
+        const options = { subject }
 
         const tags = child.listView.tagsUri
           ? graph.findAll($rdf.namedNode(child.listView.tagsUri), options)
@@ -188,7 +190,7 @@ export class EntityConfig {
           : []
 
         const stateChildren = _.get(meta, 'state.children', {})
-        const prefix = stateChildren[rdfSubject.value] === 'DRAFT' ? '[DRAFT] ' : ''
+        const prefix = stateChildren[subject.value] === 'DRAFT' ? '[DRAFT] ' : ''
 
         return {
           title: prefix + graph.findOne(DCT('title'), options),

--- a/src/entity/EntityConfig.ts
+++ b/src/entity/EntityConfig.ts
@@ -194,6 +194,7 @@ export class EntityConfig {
 
         return {
           title: prefix + graph.findOne(DCT('title'), options),
+          // todo: shouldn't we use this.createUrl(this.getChildUrlPrefix(child), id) for the link?
           link: `/${this.getChildUrlPrefix(child)}/${id}`,
           description: graph.findOne(DCT('description'), options),
           tags,


### PR DESCRIPTION
Basically this is a refactored version of the [solution suggested by @qplevier].

Whereas the current implementation picks the *first* item from the list of `targetClassUris`, we now check *all* specified target classes, i.e. both `dcat:Resource` and its subclasses. As a result, the list of matched subjects is likely to contain duplicates, e.g. one for `dcat:Resource` and one for `dcat:Catalog`, but these are removed with the help of `Set`.

Also added some type specifications, for clarity, and changed the arrow function argument.

fixes #210

### Rationale

As far as I can see, the goal in `EntityConfig.createChildrenList()` is to create a list summarizing all the child resources.
For this reason it needs to obtain all subjects matching the type `dcat:Resource` or one of its subclasses.

Because the data graph only contains triples describing the child resources, it should be sufficient to grab unique subjects matching *any* of the target classes defined in the active resource definition.

Notes: 

- The FDP reference implementation specifies both `<subject> a dcat:Resource, dcat:Catalog`. This seems redundant, knowning that `dcat:Catalog` is a subclass of `dcat:Resource`. However, the client is not aware of the DCAT class hierarchy, because there are no explicit `rdfs:subClassOf ` statements in the data graph, and it has not loaded the [dcat spec].

[solution suggested by @qplevier]: https://github.com/FAIRDataTeam/FAIRDataPoint-client/issues/210#issuecomment-3270668659

[dcat spec]: https://www.w3.org/ns/dcat3.ttl