### PR TITLE
Add CONTRIBUTING.md with guidelines for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Guidelines for contributors
+
+## Pull Requests
+
+All contributions must be made via Pull Requests (PRs).
+
+>[!IMPORTANT]
+>Any form of generated code (AI, LLM, NLP, etc.) ***MUST*** be clearly labeled as *"CONTAINS GENERATED CODE"* in the PR.
+
+- PRs must contain a clear and detailed summary of the changes they introduce and the rationale behind those changes
+- PRs must include links to relevant issues, if available
+- PRs must be of reasonable size, so they can be reviewed properly


### PR DESCRIPTION
Added contribution guidelines, specifically discussing PR requirements.

The goal is to discourage extremely large PRs and *vibe coding* practices, such as #231, because these require an excessive amount of time to review.
